### PR TITLE
Add configurable batch size

### DIFF
--- a/cyclegan.py
+++ b/cyclegan.py
@@ -48,7 +48,7 @@ def parseArguments():
     parser.add_argument("-l", "--lrate", help="Learning rate", type=float, default=LEARNING_RATE)
     parser.add_argument("-c", "--check", help="Location of checkpoint  file where model will be stored", type=str,
                         default=CHECKPOINT_FILE)
-    parser.add_argument("-sl", "--softL", help="Set to True for random real labels around 1.0", type=bool,
+    parser.add_argument("-sl", "--softL", help="Set to True for random real labels around 1.0", action='store_true',
                         default=SOFT_LABELS)
     parser.add_argument('-b', '--batch', '--batch-size', help='Batch size', type=int, default=BATCH_SIZE,
                         dest='batch_size')

--- a/cyclegan.py
+++ b/cyclegan.py
@@ -107,32 +107,6 @@ class Images():
         image.set_shape([self.image_size, self.image_size, 3])
         return image
 
-
-class ImageCache:
-    def __init__(self, cache_size=30):
-        self.cache_size = cache_size
-        self.images = []
-
-    def fetch(self, image):
-        if self.cache_size == 0:
-            return image
-
-        p = random.random()
-        if p > 0.5 and len(self.images) > 0:
-            # use and replace old image.
-            random_id = random.randrange(len(self.images))
-            retval = self.images[random_id].copy()
-            if len(self.images) < self.cache_size:
-                self.images.append(image.copy())
-            else:
-                self.images[random_id] = image.copy()
-            return retval
-        else:
-            if len(self.images) < self.cache_size:
-                self.images.append(image.copy())
-            return image
-
-
 # DEFINE OUR LOAD DATA OPERATIONS
 # -------------------------------------------------------
 # DEFINE OUR SAMPLING FUNCTIONS

--- a/cyclegan.py
+++ b/cyclegan.py
@@ -3,7 +3,6 @@ import random
 import os
 import time
 from glob import glob
-from six.moves import xrange
 import numpy as np
 import scipy.misc
 import argparse
@@ -11,11 +10,8 @@ import tensorflow as tf
 import utils
 
 LOG_DIR = './log/'
-A_DIR = './data/trainA/*.jpg'
-B_DIR = './data/trainB/*.jpg'
-A_TEST_DIR = './data/testA/*.jpg'
-B_TEST_DIR = './data/testB/*.jpg'
 
+BATCH_SIZE = 1
 MAX_TRAIN_TIME_MINS = 600
 
 SAMPLE_STEP = 10
@@ -32,266 +28,242 @@ totalEpochs = 200
 
 CHECKPOINT_FILE = './checkpoint/cyclegan.ckpt'
 
+
 # READ INPUT PARAMS
 def parseArguments():
-	# Create argument parser
-	parser = argparse.ArgumentParser()
+    # Create argument parser
+    parser = argparse.ArgumentParser()
 
-	# Optional arguments
-	parser.add_argument("-tA", "--trainA", help="Path to  trainA dir.", type=str, default=A_DIR)
-	parser.add_argument("-tB", "--trainB", help="Path to  trainB dir.", type=str, default=B_DIR)
-	parser.add_argument("-ttA", "--testA", help="Path to  testA dir.", type=str, default=A_TEST_DIR)
-	parser.add_argument("-ttB", "--testB", help="Path to  testB dir.", type=str, default=B_TEST_DIR)
-	parser.add_argument("-t", "--time", help="Max time (mins) to run training", type=int, default=60 * 10)
-	parser.add_argument("-l", "--lrate", help="Learning rate", type=float, default=LEARNING_RATE)
-	parser.add_argument("-c", "--check", help="Location of checkpoint  file where model will be stored", type=str, default=CHECKPOINT_FILE)
+    # Optional arguments
+    parser.add_argument('--log', '--logdir', dest='logdir', help='Log directory', default=LOG_DIR)
+    parser.add_argument('-i', '--input', '--input_prefix', dest='input_prefix', help="Input prefix for tfrecords files.", required=True)
+    parser.add_argument("-t", "--time", help="Max time (mins) to run training", type=int, default=60 * 10)
+    parser.add_argument("-l", "--lrate", help="Learning rate", type=float, default=LEARNING_RATE)
+    parser.add_argument("-c", "--check", help="Location of checkpoint  file where model will be stored", type=str,
+                        default=CHECKPOINT_FILE)
+    parser.add_argument('-b', '--batch', '--batch-size', help='Batch size', type=int, default=BATCH_SIZE,
+                        dest='batch_size')
 
-	# Parse arguments
-	args = parser.parse_args()
+    # Parse arguments
+    args = parser.parse_args()
 
-	return args
+    return args
+
+def to_image(data):
+    return tf.image.convert_image_dtype((data + 1.) / 2., tf.uint8)
+
+
+def batch_to_image(batch):
+    return tf.map_fn(to_image, batch, dtype=tf.uint8)
+
+
+class Images():
+    def __init__(self, tfrecords_file, image_size=256, batch_size=1, num_threads=2, name=''):
+        self.tfrecords_file = tfrecords_file
+        self.image_size = image_size
+        self.batch_size = batch_size
+        self.num_threads = num_threads
+        self.name = name
+
+    def feed(self):
+        with tf.name_scope(self.name):
+            filename_queue = tf.train.string_input_producer([self.tfrecords_file])
+            reader = tf.TFRecordReader()
+
+            _, serialized_example = reader.read(filename_queue)
+            features = tf.parse_single_example(
+                serialized_example,
+                features={
+                    'image/file_name': tf.FixedLenFeature([], tf.string),
+                    'image/encoded_image': tf.FixedLenFeature([], tf.string),
+                })
+
+            image_buffer = features['image/encoded_image']
+            image = tf.image.decode_jpeg(image_buffer, channels=3)
+            image = self.preprocess(image)
+            images = tf.train.shuffle_batch(
+                [image], batch_size=self.batch_size, num_threads=self.num_threads,
+                capacity=100 + 3 * self.batch_size,
+                min_after_dequeue=100
+            )
+
+            tf.summary.image('_input', images)
+        return images
+
+    def preprocess(self, image):
+        image = tf.image.resize_images(image, size=(self.image_size, self.image_size))
+        image = tf.image.convert_image_dtype(image, dtype=tf.float32)
+        image = (image / 127.5) - 1.
+        image.set_shape([self.image_size, self.image_size, 3])
+        return image
+
+class ImageCache:
+    def __init__(self, cache_size=30):
+        self.cache_size = cache_size
+        self.images = []
+
+    def fetch(self, image):
+        if self.cache_size == 0:
+            return image
+
+        p = random.random()
+        if p > 0.5 and len(self.images) > 0:
+            # use and replace old image.
+            random_id = random.randrange(len(self.images))
+            retval = self.images[random_id].copy()
+            if len(self.images) < self.cache_size:
+                self.images.append(image.copy())
+            else:
+                self.images[random_id] = image.copy()
+            return retval
+        else:
+            if len(self.images) < self.cache_size:
+                self.images.append(image.copy())
+            return image
+
+
 # DEFINE OUR LOAD DATA OPERATIONS
 # -------------------------------------------------------
-def load_data(image_path, flip=True, is_test=False):
-	img_A, img_B = load_image(image_path)
-	img_A, img_B = preprocess_A_and_B(img_A, img_B, flip=flip, is_test=is_test)
-
-	img_A = img_A / 127.5 - 1.
-	img_B = img_B / 127.5 - 1.
-
-	img_AB = np.concatenate((img_A, img_B), axis=2)
-	# img_AB shape: (fine_size, fine_size, input_c_dim + output_c_dim)
-	return img_AB
-
-
-def load_image(image_path):
-	img_A = scipy.misc.imread(image_path[0], mode='RGB').astype(np.float)
-	img_B = scipy.misc.imread(image_path[1], mode='RGB').astype(np.float)
-	return img_A, img_B
-
-
-def preprocess_A_and_B(img_A, img_B, load_size=286, fine_size=256, flip=True, is_test=False):
-	if is_test:
-		img_A = scipy.misc.imresize(img_A, [fine_size, fine_size])
-		img_B = scipy.misc.imresize(img_B, [fine_size, fine_size])
-	else:
-		img_A = scipy.misc.imresize(img_A, [load_size, load_size])
-		img_B = scipy.misc.imresize(img_B, [load_size, load_size])
-
-		h1 = int(np.ceil(np.random.uniform(1e-2, load_size - fine_size)))
-		w1 = int(np.ceil(np.random.uniform(1e-2, load_size - fine_size)))
-		img_A = img_A[h1:h1 + fine_size, w1:w1 + fine_size]
-		img_B = img_B[h1:h1 + fine_size, w1:w1 + fine_size]
-
-		if flip and np.random.random() > 0.5:
-			img_A = np.fliplr(img_A)
-			img_B = np.fliplr(img_B)
-
-	return img_A, img_B
-
-
 # DEFINE OUR SAMPLING FUNCTIONS
 # -------------------------------------------------------
 
 def inverse_transform(images):
-	return (images + 1.) / 2.
+    return (images + 1.) / 2.
+
 
 def merge(images, size):
-	h, w = images.shape[1], images.shape[2]
-	img = np.zeros((h * size[0], w * size[1], 3))
-	for idx, image in enumerate(images):
-		i = idx % size[1]
-		j = idx // size[1]
-		img[j * h:j * h + h, i * w:i * w + w, :] = image
+    h, w = images.shape[1], images.shape[2]
+    img = np.zeros((h * size[0], w * size[1], 3))
+    for idx, image in enumerate(images):
+        i = idx % size[1]
+        j = idx // size[1]
+        img[j * h:j * h + h, i * w:i * w + w, :] = image
 
-	return img
+    return img
 
-def prepare_sample_source():
-	# WE WILL USE THE SAME SAMPLE EVERY TIME TO SEE EXPLICIT PROGRESS DURING TRAINING
-	# WE GRAB THE FIRST IMAGE FROM THE TEST FOLDER AND LOAD IT
-	sample_X_image_path = glob(A_TEST_DIR)[0]
-	sample_Y_image_path = glob(B_TEST_DIR)[0]
+def sample_model(sess, idx):
+    # RUN THEM THROUGH THE MODEL
+    x_val, y_val, y_samp, x_samp, x_cycle_samp, y_cycle_samp = sess.run(
+        [test_X, test_Y, testG, testF, testG_back, testF_back])
 
-	print("--------------------------------------------")
-	print("sample_X_image_path=", sample_X_image_path)
-	print("sample_Y_image_path=", sample_Y_image_path)
-	print("--------------------------------------------")
+    # GRAB THE RETURNED RESULTS AND COLOR CORRECT / MERGE DOWN TO SINGLE IMAGE FILE EACH
+    pretty_x = merge(inverse_transform(x_samp), [1, 1])
+    pretty_y = merge(inverse_transform(y_samp), [1, 1])
+    pretty_x_cycle = merge(inverse_transform(x_cycle_samp), [1, 1])
+    pretty_y_cycle = merge(inverse_transform(y_cycle_samp), [1, 1])
 
-	sample_X_image = scipy.misc.imread(sample_X_image_path, mode='RGB').astype(np.float)
-	sample_Y_image = scipy.misc.imread(sample_Y_image_path, mode='RGB').astype(np.float)
-	# RESIZE TO BE SURE
-	sample_X_image = scipy.misc.imresize(sample_X_image, [256, 256])
-	sample_Y_image = scipy.misc.imresize(sample_Y_image, [256, 256])
-	sample_X_normalized = sample_X_image / 127.5 - 1.
-	sample_Y_normalized = sample_Y_image / 127.5 - 1.
-	sample_feed_data = np.concatenate( (sample_X_normalized, sample_Y_normalized), axis=2)
-	sample_feed_data = [sample_feed_data]
-	sample_feed_data = np.array(sample_feed_data).astype(np.float32)
-	return sample_X_image, sample_Y_image, sample_feed_data    
+    scipy.misc.imsave('./samples/{}_X.jpg'.format(idx), x_val[0])
+    scipy.misc.imsave('./samples/{}_Y.jpg'.format(idx), y_val[0])
 
-def sample_model(epoch, idx, sample_X_image, sample_Y_image, sample_feed_data):
+    scipy.misc.imsave('./samples/{}_X_2Y.jpg'.format(idx), y_samp[0])
+    scipy.misc.imsave('./samples/{}_Y_2X.jpg'.format(idx), x_samp[0])
 
-	# RUN THEM THROUGH THE MODEL
-	generated_X_sample, generated_Y_sample = sess.run( 
-		[ genF, genG ], 
-		feed_dict={ real_data:sample_feed_data })
-
-	# GRAB THE RETURNED RESULTS AND COLOR CORRECT / MERGE DOWN TO SINGLE IMAGE FILE EACH
-	prettify_generated_X = merge( inverse_transform( generated_X_sample), [1,1])
-	prettify_generated_Y = merge( inverse_transform( generated_Y_sample), [1,1])
-
-	# CONVERT THE FIRST PASS OF GENERATOR RESULTS INTO DISCRETE IMAGES
-	# TO PASS BACK THROUGH THE MODEL, COMPLETING THE ROUNDTRIP CYCLE TEST
-	# I.E.  X=> G(X)=> F(G(X))=> X^   
-	# and   Y=> F(Y)=> G(F(Y))=> Y^
-	image_returnX2Y = merge(generated_X_sample, [1,1])
-	image_returnY2X = merge(generated_Y_sample, [1,1])
-	images_XY_return = np.concatenate((image_returnX2Y, image_returnY2X), axis=2)
-	images_XY_return = [images_XY_return]
-	images_XY_return = np.array(images_XY_return).astype(np.float32)
-
-	# RUN THE RESULTS OF THE FIRST PASS THROUGH THE MODEL A SECOND TIME TO 
-	# ATTEMPT TO CONVERT THEM BACK TO THEIR ORIGINAL MAPPINGS
-	X_full_cycle, Y_full_cycle = sess.run(
-		[genF, genG ], feed_dict={ real_data:images_XY_return}
-	)
-	
-	# PREPARE THE FULLY CYCLED RESULTS FOR DISPLAY
-	X_2Y_2X = merge( inverse_transform( X_full_cycle ), [1,1])
-	Y_2X_2Y = merge( inverse_transform( Y_full_cycle ), [1,1])
-
-	scipy.misc.imsave( './samples/X.jpg', sample_X_image )
-	scipy.misc.imsave( './samples/Y.jpg', sample_Y_image )
-
-	scipy.misc.imsave( './samples/X_2Y.jpg', prettify_generated_Y )
-	scipy.misc.imsave( './samples/Y_2X.jpg', prettify_generated_X )
-
-	scipy.misc.imsave( './samples/X_2Y_2X.jpg', X_2Y_2X )
-	scipy.misc.imsave( './samples/Y_2X_2Y.jpg', Y_2X_2Y )
+    scipy.misc.imsave('./samples/{}_X_2Y_2X.jpg'.format(idx), x_cycle_samp[0])
+    scipy.misc.imsave('./samples/{}_Y_2X_2Y.jpg'.format(idx), y_cycle_samp[0])
 
 
 # DEFINE OUR CUSTOM LAYERS AND ACTIVATION FUNCTIONS
 # -------------------------------------------------------
 def batch_norm(x, name="batch_norm", reuse=False):
-	return tf.contrib.layers.batch_norm(x, decay=0.9, updates_collections=None, epsilon=1e-5, scale=True, scope=name, reuse=reuse)
+    return tf.contrib.layers.batch_norm(x, decay=0.9, updates_collections=None, epsilon=1e-5, scale=True, scope=name,
+                                        reuse=reuse)
 
 
 def conv2d(input_, output_dim, ks=4, s=2, stddev=0.02, padding='SAME', name="conv2d", reuse=False):
-	with tf.variable_scope(name):
-		return tf.layers.conv2d(input_,
-								filters=output_dim, kernel_size=ks, strides=(s, s),
-								padding=padding, kernel_initializer=tf.truncated_normal_initializer(stddev=stddev),
-								bias_initializer=None, reuse=reuse)
+    with tf.variable_scope(name):
+        return tf.layers.conv2d(input_,
+                                filters=output_dim, kernel_size=ks, strides=(s, s),
+                                padding=padding, kernel_initializer=tf.truncated_normal_initializer(stddev=stddev),
+                                bias_initializer=None, reuse=reuse)
 
 
 def deconv2d(input_, output_dim, ks=4, s=2, stddev=0.02, name="deconv2d", reuse=False):
-	with tf.variable_scope(name):
-		return tf.layers.conv2d_transpose(input_,
-										  filters=output_dim, kernel_size=ks, strides=(s, s), padding='SAME',
-										  kernel_initializer=tf.truncated_normal_initializer(stddev=stddev),
-										  bias_initializer=None, reuse=reuse)
+    with tf.variable_scope(name):
+        return tf.layers.conv2d_transpose(input_,
+                                          filters=output_dim, kernel_size=ks, strides=(s, s), padding='SAME',
+                                          kernel_initializer=tf.truncated_normal_initializer(stddev=stddev),
+                                          bias_initializer=None, reuse=reuse)
 
 
 def lrelu(x, leak=0.2, name="lrelu"):
-	return tf.maximum(x, leak * x)
-
-
-# DEFINE OUR RUNNING POOL OF 50 FAKES FOR THE DISCRIMINATOR
-# -------------------------------------------------------
-class ImagePool(object):
-	def __init__(self, maxsize=50):
-		self.maxsize = maxsize
-		self.num_img = 0
-		self.images = []
-
-	def __call__(self, image):
-		if self.maxsize == 0:
-			return image
-		if self.num_img < self.maxsize:
-			self.images.append(image)
-			return image
-		if np.random.rand > 0.5:
-			idx = int(np.random.rand * self.maxsize)
-			tmp = copy.copy(self.images[idx])
-			self.images[idx] = image
-			return tmp
-		else:
-			return image
+    return tf.maximum(x, leak * x)
 
 
 # DEFINE OUR GENERATOR
 # -------------------------------------------------------
 def generator(image, reuse=False, name="generator"):
-	with tf.variable_scope(name):
-		# image is 256 x 256 x input_c_dim
-		if reuse:
-			tf.get_variable_scope().reuse_variables()
-		else:
-			tf.variable_scope(tf.get_variable_scope(), reuse=False)
-			assert tf.get_variable_scope().reuse == False
+    with tf.variable_scope(name):
+        # image is 256 x 256 x input_c_dim
+        if reuse:
+            tf.get_variable_scope().reuse_variables()
+        else:
+            tf.variable_scope(tf.get_variable_scope(), reuse=False)
+            assert tf.get_variable_scope().reuse == False
 
-		def residule_block(x, dim, ks=3, s=1, name='res', reuse=reuse):
-			p = int((ks - 1) / 2)
-			y = tf.pad(x, [[0, 0], [p, p], [p, p], [0, 0]], "REFLECT")
-			y = batch_norm(conv2d(y, dim, ks, s, padding='VALID', name=name + '_c1', reuse=reuse), name + '_bn1', reuse=reuse)
-			y = tf.pad(tf.nn.relu(y), [[0, 0], [p, p], [p, p], [0, 0]], "REFLECT")
-			y = batch_norm(conv2d(y, dim, ks, s, padding='VALID', name=name + '_c2', reuse=reuse), name + '_bn2', reuse=reuse)
-			return y + x
+        def residual_block(x, dim, ks=3, s=1, name='res', reuse=reuse):
+            p = int((ks - 1) / 2)
+            y = tf.pad(x, [[0, 0], [p, p], [p, p], [0, 0]], "REFLECT")
+            y = batch_norm(conv2d(y, dim, ks, s, padding='VALID', name=name + '_c1', reuse=reuse), name + '_bn1',
+                           reuse=reuse)
+            y = tf.pad(tf.nn.relu(y), [[0, 0], [p, p], [p, p], [0, 0]], "REFLECT")
+            y = batch_norm(conv2d(y, dim, ks, s, padding='VALID', name=name + '_c2', reuse=reuse), name + '_bn2',
+                           reuse=reuse)
+            return y + x
 
-		s = 256
-		# Justin Johnson's model from https://github.com/jcjohnson/fast-neural-style/
-		# The network with 9 blocks consists of: c7s1-32, d64, d128, R128, R128, R128,
-		# R128, R128, R128, R128, R128, R128, u64, u32, c7s1-3
-		c0 = tf.pad(image, [[0, 0], [3, 3], [3, 3], [0, 0]], "REFLECT")
-		c1 = tf.nn.relu(batch_norm(conv2d(c0, 32, 7, 1, padding='VALID', name='g_e1_c', reuse=reuse), 'g_e1_bn', reuse=reuse))
-		c2 = tf.nn.relu(batch_norm(conv2d(c1, 64, 3, 2, name='g_e2_c', reuse=reuse), 'g_e2_bn', reuse=reuse))
-		c3 = tf.nn.relu(batch_norm(conv2d(c2, 128, 3, 2, name='g_e3_c', reuse=reuse), 'g_e3_bn', reuse=reuse))
-		# define G network with 9 resnet blocks
-		r1 = residule_block(c3, 128, name='g_r1', reuse=reuse)
-		r2 = residule_block(r1, 128, name='g_r2', reuse=reuse)
-		r3 = residule_block(r2, 128, name='g_r3', reuse=reuse)
-		r4 = residule_block(r3, 128, name='g_r4', reuse=reuse)
-		r5 = residule_block(r4, 128, name='g_r5', reuse=reuse)
-		r6 = residule_block(r5, 128, name='g_r6', reuse=reuse)
-		r7 = residule_block(r6, 128, name='g_r7', reuse=reuse)
-		r8 = residule_block(r7, 128, name='g_r8', reuse=reuse)
-		r9 = residule_block(r8, 128, name='g_r9', reuse=reuse)
+        s = 256
+        # Justin Johnson's model from https://github.com/jcjohnson/fast-neural-style/
+        # The network with 9 blocks consists of: c7s1-32, d64, d128, R128, R128, R128,
+        # R128, R128, R128, R128, R128, R128, u64, u32, c7s1-3
+        c0 = tf.pad(image, [[0, 0], [3, 3], [3, 3], [0, 0]], "REFLECT")
+        c1 = tf.nn.relu(
+            batch_norm(conv2d(c0, 32, 7, 1, padding='VALID', name='g_e1_c', reuse=reuse), 'g_e1_bn', reuse=reuse))
+        c2 = tf.nn.relu(batch_norm(conv2d(c1, 64, 3, 2, name='g_e2_c', reuse=reuse), 'g_e2_bn', reuse=reuse))
+        c3 = tf.nn.relu(batch_norm(conv2d(c2, 128, 3, 2, name='g_e3_c', reuse=reuse), 'g_e3_bn', reuse=reuse))
+        # define G network with 9 resnet blocks
+        r1 = residual_block(c3, 128, name='g_r1', reuse=reuse)
+        r2 = residual_block(r1, 128, name='g_r2', reuse=reuse)
+        r3 = residual_block(r2, 128, name='g_r3', reuse=reuse)
+        r4 = residual_block(r3, 128, name='g_r4', reuse=reuse)
+        r5 = residual_block(r4, 128, name='g_r5', reuse=reuse)
+        r6 = residual_block(r5, 128, name='g_r6', reuse=reuse)
+        r7 = residual_block(r6, 128, name='g_r7', reuse=reuse)
+        r8 = residual_block(r7, 128, name='g_r8', reuse=reuse)
+        r9 = residual_block(r8, 128, name='g_r9', reuse=reuse)
 
-		d1 = deconv2d(r9, 64, 3, 2, name='g_d1_dc', reuse=reuse)
-		d1 = tf.nn.relu(batch_norm(d1, 'g_d1_bn', reuse=reuse))
+        d1 = deconv2d(r9, 64, 3, 2, name='g_d1_dc', reuse=reuse)
+        d1 = tf.nn.relu(batch_norm(d1, 'g_d1_bn', reuse=reuse))
 
-		d2 = deconv2d(d1, 32, 3, 2, name='g_d2_dc', reuse=reuse)
-		d2 = tf.nn.relu(batch_norm(d2, 'g_d2_bn', reuse=reuse))
-		d2 = tf.pad(d2, [[0, 0], [3, 3], [3, 3], [0, 0]], "REFLECT")
-		pred = conv2d(d2, 3, 7, 1, padding='VALID', name='g_pred_c', reuse=reuse)
-		pred = tf.nn.tanh(batch_norm(pred, 'g_pred_bn', reuse=reuse))
+        d2 = deconv2d(d1, 32, 3, 2, name='g_d2_dc', reuse=reuse)
+        d2 = tf.nn.relu(batch_norm(d2, 'g_d2_bn', reuse=reuse))
+        d2 = tf.pad(d2, [[0, 0], [3, 3], [3, 3], [0, 0]], "REFLECT")
+        pred = conv2d(d2, 3, 7, 1, padding='VALID', name='g_pred_c', reuse=reuse)
+        pred = tf.nn.tanh(batch_norm(pred, 'g_pred_bn', reuse=reuse))
 
-		return pred
-
+        return pred
 
 
 # DEFINE OUR DISCRIMINATOR
 # -------------------------------------------------------
 def discriminator(image, reuse=False, name="discriminator"):
-	with tf.variable_scope(name):
-		# image is 256 x 256 x input_c_dim
-		if reuse:
-			tf.get_variable_scope().reuse_variables()
-		else:
-			tf.variable_scope(tf.get_variable_scope(), reuse=False)
-			assert tf.get_variable_scope().reuse == False
+    with tf.variable_scope(name):
+        # image is 256 x 256 x input_c_dim
+        if reuse:
+            tf.get_variable_scope().reuse_variables()
+        else:
+            tf.variable_scope(tf.get_variable_scope(), reuse=False)
+            assert tf.get_variable_scope().reuse == False
 
-		h0 = lrelu(conv2d(image, 64, reuse=reuse, name='d_h0_conv'))
-		# h0 is (128 x 128 x self.df_dim)
-		h1 = lrelu(batch_norm(conv2d(h0, 128, name='d_h1_conv', reuse=reuse), 'd_bn1', reuse=reuse))
-		# h1 is (64 x 64 x self.df_dim*2)
-		h2 = lrelu(batch_norm(conv2d(h1, 256, name='d_h2_conv', reuse=reuse), 'd_bn2', reuse=reuse))
-		# h2 is (32x 32 x self.df_dim*4)
-		h3 = lrelu(batch_norm(conv2d(h2, 512, s=1, name='d_h3_conv', reuse=reuse), 'd_bn3', reuse=reuse))
-		# h3 is (32 x 32 x self.df_dim*8)
-		h4 = conv2d(h3, 1, s=1, name='d_h3_pred', reuse=reuse)
-		# h4 is (32 x 32 x 1)
-		return h4
+        h0 = lrelu(conv2d(image, 64, reuse=reuse, name='d_h0_conv'))
+        # h0 is (128 x 128 x self.df_dim)
+        h1 = lrelu(batch_norm(conv2d(h0, 128, name='d_h1_conv', reuse=reuse), 'd_bn1', reuse=reuse))
+        # h1 is (64 x 64 x self.df_dim*2)
+        h2 = lrelu(batch_norm(conv2d(h1, 256, name='d_h2_conv', reuse=reuse), 'd_bn2', reuse=reuse))
+        # h2 is (32x 32 x self.df_dim*4)
+        h3 = lrelu(batch_norm(conv2d(h2, 512, s=1, name='d_h3_conv', reuse=reuse), 'd_bn3', reuse=reuse))
+        # h3 is (32 x 32 x self.df_dim*8)
+        h4 = conv2d(h3, 1, s=1, name='d_h3_pred', reuse=reuse)
+        # h4 is (32 x 32 x 1)
+        return h4
 
 
 args = parseArguments()
@@ -299,29 +271,25 @@ args = parseArguments()
 # Raw print arguments
 print("You are running the script with arguments: ")
 for a in args.__dict__:
-	print(str(a) + ": " + str(args.__dict__[a]))
+    print(str(a) + ": " + str(args.__dict__[a]))
 
-A_DIR = args.trainA
-B_DIR = args.trainB
-A_TEST_DIR = args.testA
-B_TEST_DIR = args.testB
 MAX_TRAIN_TIME_MINS = args.time
 LEARNING_RATE = args.lrate
 CHECKPOINT_FILE = args.check
+BATCH_SIZE = args.batch_size
 
 # DEFINE OUR MODEL AND LOSS FUNCTIONS
 # -------------------------------------------------------
 
-real_data = tf.placeholder(tf.float32, [None, 256, 256, 6], name='real_X_and_Y_images')
-real_X = real_data[:, :, :, :3]
-real_Y = real_data[:, :, :, 3:6]
+real_X = Images(args.input_prefix + '_trainA.tfrecords', batch_size=BATCH_SIZE, name='real_X').feed()
+real_Y = Images(args.input_prefix + '_trainB.tfrecords', batch_size=BATCH_SIZE, name='real_Y').feed()
 
 # genG(X) => Y            - fake_B
 genG = generator(real_X, name="generatorG")
-# genF( genG(Y) ) => Y    - fake_A_
-genF_back = generator(genG, name="generatorF")
 # genF(Y) => X            - fake_A
-genF = generator(real_Y, name="generatorF", reuse=True)
+genF = generator(real_Y, name="generatorF")
+# genF( genG(Y) ) => Y    - fake_A_
+genF_back = generator(genG, name="generatorF", reuse=True)
 # genF( genG(X)) => X     - fake_B_
 genG_back = generator(genF, name="generatorG", reuse=True)
 
@@ -331,12 +299,12 @@ discY_fake = discriminator(genG, reuse=False, name="discY")
 discX_fake = discriminator(genF, reuse=False, name="discX")
 
 g_loss_G = tf.reduce_mean((discY_fake - tf.ones_like(discY_fake)) ** 2) \
-		   + L1_lambda * tf.reduce_mean(tf.abs(real_X - genF_back)) \
-		   + L1_lambda * tf.reduce_mean(tf.abs(real_Y - genG_back))
+           + L1_lambda * tf.reduce_mean(tf.abs(real_X - genF_back)) \
+           + L1_lambda * tf.reduce_mean(tf.abs(real_Y - genG_back))
 
 g_loss_F = tf.reduce_mean((discX_fake - tf.ones_like(discX_fake)) ** 2) \
-		   + L1_lambda * tf.reduce_mean(tf.abs(real_X - genF_back)) \
-		   + L1_lambda * tf.reduce_mean(tf.abs(real_Y - genG_back))
+           + L1_lambda * tf.reduce_mean(tf.abs(real_X - genF_back)) \
+           + L1_lambda * tf.reduce_mean(tf.abs(real_Y - genG_back))
 
 fake_X_sample = tf.placeholder(tf.float32, [None, 256, 256, 3], name="fake_X_sample")
 fake_Y_sample = tf.placeholder(tf.float32, [None, 256, 256, 3], name="fake_Y_sample")
@@ -356,11 +324,13 @@ DX_loss_real = tf.reduce_mean((DX - tf.ones_like(DX)) ** 2)
 DX_loss_fake = tf.reduce_mean((DX_fake_sample - tf.zeros_like(DX_fake_sample)) ** 2)
 DX_loss = (DX_loss_real + DX_loss_fake) / 2
 
-test_X = tf.placeholder(tf.float32, [None, 256, 256, 3], name='testX')
-test_Y = tf.placeholder(tf.float32, [None, 256, 256, 3], name='testY')
+test_X = Images(args.input_prefix + '_testA.tfrecords', name='test_A').feed()
+test_Y = Images(args.input_prefix + '_testB.tfrecords', name='test_B').feed()
 
-testY = generator(test_X, name="generatorG", reuse=True)
-testX = generator(test_Y, name="generatorF", reuse=True)
+testG = generator(test_X, name="generatorG", reuse=True)
+testF = generator(test_Y, name="generatorF", reuse=True)
+testF_back = generator(testG, name="generatorF", reuse=True)
+testG_back = generator(testF, name="generatorG", reuse=True)
 
 t_vars = tf.trainable_variables()
 DY_vars = [v for v in t_vars if 'discY' in v.name]
@@ -386,10 +356,10 @@ imgY = tf.summary.image('real_Y', tf.transpose(real_Y, perm=[0, 2, 3, 1]), max_o
 imgF = tf.summary.image('genF', tf.transpose(genF, perm=[0, 2, 3, 1]), max_outputs=3)
 
 DY_sum = tf.summary.merge(
-	[DY_loss_sum, DY_loss_real_sum, DY_loss_fake_sum]
+    [DY_loss_sum, DY_loss_real_sum, DY_loss_fake_sum]
 )
 DX_sum = tf.summary.merge(
-	[DX_loss_sum, DX_loss_real_sum, DX_loss_fake_sum]
+    [DX_loss_sum, DX_loss_real_sum, DX_loss_fake_sum]
 )
 
 images_sum = tf.summary.merge([imgX, imgG, imgY, imgF])
@@ -398,21 +368,21 @@ images_sum = tf.summary.merge([imgX, imgG, imgY, imgF])
 # -------------------------------------------------------
 
 DX_optim = tf.train.AdamOptimizer(LEARNING_RATE, MOMENTUM) \
-	.minimize(DX_loss, var_list=DX_vars)
+    .minimize(DX_loss, var_list=DX_vars)
 
 DY_optim = tf.train.AdamOptimizer(LEARNING_RATE, MOMENTUM) \
-	.minimize(DY_loss, var_list=DY_vars)
+    .minimize(DY_loss, var_list=DY_vars)
 
 G_optim = tf.train.AdamOptimizer(LEARNING_RATE, MOMENTUM) \
-	.minimize(g_loss_G, var_list=g_vars_G)
+    .minimize(g_loss_G, var_list=g_vars_G)
 
 F_optim = tf.train.AdamOptimizer(LEARNING_RATE, MOMENTUM) \
-	.minimize(g_loss_F, var_list=g_vars_F)
+    .minimize(g_loss_F, var_list=g_vars_F)
 
 # CREATE AND RUN OUR TRAINING LOOP
 # -------------------------------------------------------
 
-saver = tf.train.Saver(tf.global_variables(), max_to_keep = 5)
+saver = tf.train.Saver(tf.global_variables(), max_to_keep=5)
 
 print("Starting the time")
 timer = utils.Timer()
@@ -420,85 +390,70 @@ timer = utils.Timer()
 sess = tf.Session()
 sess.run(tf.global_variables_initializer())
 
-ckpt = tf.train.get_checkpoint_state('./checkpoint/')
-
-if ckpt and ckpt.model_checkpoint_path:
-	saver.restore(sess, ckpt.model_checkpoint_path)
-	print("Reading model parameters from %s" % ckpt.model_checkpoint_path)
-else:
-	print("Created model with fresh parameters.")
-	sess.run(tf.global_variables_initializer())
+# ckpt = tf.train.get_checkpoint_state('./checkpoint/')
+#
+# if ckpt and ckpt.model_checkpoint_path:
+#     saver.restore(sess, ckpt.model_checkpoint_path)
+#     print("Reading model parameters from %s" % ckpt.model_checkpoint_path)
+# else:
+#     print("Created model with fresh parameters.")
+sess.run(tf.global_variables_initializer())
+coord = tf.train.Coordinator()
+threads = tf.train.start_queue_runners(sess=sess, coord=coord)
 
 writer = tf.summary.FileWriter("./log", sess.graph)
 
-is_early_break = False
+try:
+    counter = 0
+    while not coord.should_stop():
 
-sample_X_image, sample_Y_image, sample_feed_data = prepare_sample_source()
+        # FORWARD PASS
+        generated_X, generated_Y = sess.run([genF, genG])
 
-for epoch in xrange(totalEpochs):
+        # UPDATE  G
+        _, summary_str = sess.run([G_optim, G_sum])
+        writer.add_summary(summary_str, counter)
 
-	dataX = glob(A_DIR)
-	dataY = glob(B_DIR)
+        # UPDATE DY
+        _, summary_str = sess.run([DY_optim, DY_sum],
+                                  feed_dict={fake_Y_sample: generated_Y})
+        writer.add_summary(summary_str, counter)
 
-	np.random.shuffle(dataX)
-	np.random.shuffle(dataY)
-	batch_idxs = min(len(dataX), len(dataY))
+        # UPDATE F
+        _, summary_str = sess.run([F_optim, F_sum])
+        writer.add_summary(summary_str, counter)
 
-	pool = ImagePool(50)
+        # UPDATE DX
+        _, summary_str = sess.run([DX_optim, DX_sum],
+                                  feed_dict={fake_X_sample: generated_X})
+        writer.add_summary(summary_str, counter)
 
-	if is_early_break:
-		print("Finishing early...")
-		break
+        counter += 1
+        print("[%4d] time: %4.4f" % (counter, time.time() - start_time))
 
-	for idx in xrange(0, batch_idxs):
-		batch_files = zip(dataX[idx:(idx + 1)], dataY[idx:(idx + 1)])
-		batch_images = [load_data(f) for f in batch_files]
-		batch_images = np.array(batch_images).astype(np.float32)
+        if np.mod(counter, SAMPLE_STEP) == 0:
+            sample_model(sess, counter)
 
-		# FORWARD PASS
-		generated_X, generated_Y = sess.run([genF, genG],
-											feed_dict={real_data: batch_images})
-		[generated_X, generated_Y] = pool([generated_X, generated_Y])
+        if np.mod(counter, SAVE_STEP) == 0:
+            print("Running for '{0:.2}' mins, saving to {1}".format(timer.elapsed() / 60, CHECKPOINT_FILE))
+            saver.save(sess, CHECKPOINT_FILE)
 
-		# UPDATE  G
-		_, summary_str = sess.run([G_optim, G_sum], feed_dict={real_data: batch_images})
-		writer.add_summary(summary_str, counter)
+        if np.mod(counter, SAVE_STEP) == 0:
+            elapsed_min = timer.elapsed() / 60
+            if (elapsed_min >= MAX_TRAIN_TIME_MINS):
+                print(
+                    "Trained for '{0:.2}' mins and reached the max limit of {1}. Saving model.".format(elapsed_min,
+                                                                                                       MAX_TRAIN_TIME_MINS))
+                coord.request_stop()
 
-		# UPDATE DY
-		_, summary_str = sess.run([DY_optim, DY_sum],
-								  feed_dict={real_data: batch_images,
-											 fake_Y_sample: generated_Y})
-		writer.add_summary(summary_str, counter)
-
-		# UPDATE F
-		_, summary_str = sess.run([F_optim, F_sum], feed_dict={real_data: batch_images})
-		writer.add_summary(summary_str, counter)
-
-		# UPDATE DX
-		_, summary_str = sess.run([DX_optim, DX_sum],
-								  feed_dict={real_data: batch_images,
-											 fake_X_sample: generated_X})
-		writer.add_summary(summary_str, counter)
-
-		counter += 1
-		print("Epoch: [%2d] [%4d/%4d] time: %4.4f" % (epoch, idx, batch_idxs, time.time() - start_time))
-
-		if np.mod(counter, SAMPLE_STEP) == 0:
-			try:
-				sample_model(epoch, idx, sample_X_image, sample_Y_image, sample_feed_data )
-			except Exception as e:
-				print("Error happend:")
-				print(e)
-
-		if np.mod(counter, SAVE_STEP) == 0:
-			print("Running for '{0:.2}' mins, saving to {1}".format(timer.elapsed()/60, CHECKPOINT_FILE))
-			saver.save(sess, CHECKPOINT_FILE)
-
-		if np.mod(counter, SAVE_STEP) == 0:
-			elapsed_min = timer.elapsed()/60
-			if (elapsed_min >= MAX_TRAIN_TIME_MINS):
-				print("Trained for '{0:.2}' mins and reached the max limit of {1}. Saving model.".format(elapsed_min, MAX_TRAIN_TIME_MINS))
-				saver.save(sess, CHECKPOINT_FILE)
-				is_early_break = True
-				break
-
+except KeyboardInterrupt:
+    print('Interrupted')
+    coord.request_stop()
+except Exception as e:
+    coord.request_stop(e)
+finally:
+    save_path = saver.save(sess, CHECKPOINT_FILE)
+    print("Model saved in file: %s" % CHECKPOINT_FILE)
+    # When done, ask the threads to stop.
+    coord.request_stop()
+    coord.join(threads)

--- a/cyclegan.py
+++ b/cyclegan.py
@@ -25,10 +25,10 @@ TIME_CHECK_STEP = 100
 L1_lambda = 10
 LEARNING_RATE = 0.0002
 MOMENTUM = 0.5
+MAX_STEPS = 100000
 
 counter = 1
 start_time = time.time()
-totalEpochs = 200
 
 SOFT_LABELS = False
 
@@ -52,6 +52,8 @@ def parseArguments():
                         default=SOFT_LABELS)
     parser.add_argument('-b', '--batch', '--batch-size', help='Batch size', type=int, default=BATCH_SIZE,
                         dest='batch_size')
+    parser.add_argument('-s', '--sample', '--sample-freq', dest='sample_freq', help='How often to write out sample images', type=int, default=SAMPLE_STEP)
+    parser.add_argument('--checkpoint-freq', dest='checkpoint_freq', help='How often to save to the checkpoint file', type=int, default=SAVE_STEP)
 
     # Parse arguments
     args = parser.parse_args()
@@ -155,7 +157,7 @@ def merge(images, size):
 
 def sample_model(sess, idx):
     # RUN THEM THROUGH THE MODEL
-    x_val, y_val, y_samp, x_samp, x_cycle_samp, y_cycle_samp = sess.run(
+    x_val, y_val, y_samp, x_samp, y_cycle_samp, x_cycle_samp = sess.run(
         [test_X, test_Y, testG, testF, testG_back, testF_back])
 
     # GRAB THE RETURNED RESULTS AND COLOR CORRECT / MERGE DOWN TO SINGLE IMAGE FILE EACH
@@ -289,6 +291,8 @@ MAX_TRAIN_TIME_MINS = args.time
 LEARNING_RATE = args.lrate
 CHECKPOINT_FILE = args.check
 BATCH_SIZE = args.batch_size
+SAMPLE_STEP = args.sample_freq
+SAVE_STEP = args.checkpoint_freq
 SOFT_LABELS = args.softL
 
 if SOFT_LABELS:
@@ -422,7 +426,7 @@ sess.run(tf.global_variables_initializer())
 coord = tf.train.Coordinator()
 threads = tf.train.start_queue_runners(sess=sess, coord=coord)
 
-writer = tf.summary.FileWriter("./log", sess.graph)
+writer = tf.summary.FileWriter(LOG_DIR, sess.graph)
 
 cache_X = ImageCache(50)
 cache_Y = ImageCache(50)

--- a/cycleganTest.py
+++ b/cycleganTest.py
@@ -226,6 +226,7 @@ A_TEST_DIR = args.testA
 B_TEST_DIR = args.testB
 CHECKPOINT_FILE = args.check
 SAMPLES_DIR = args.samples
+os.makedirs(SAMPLES_DIR, exist_ok=True)
 
 ckpt = tf.train.get_checkpoint_state(CHECKPOINT_FILE)
 

--- a/to_tfrecords.py
+++ b/to_tfrecords.py
@@ -1,0 +1,105 @@
+import logging
+import os
+from shutil import copyfile
+import tensorflow as tf
+
+import argparse
+
+import random
+
+random.seed(1337)  # Set seed for repeatable shuffling.
+
+def exists(x):
+    for d in ['', 'trainA', 'trainB', 'testA', 'testB']:
+        path = os.path.join(x, d)
+        if not os.path.exists(path):
+            raise argparse.ArgumentTypeError(
+                '"%s" must be a valid directory containing trainA, trainB, testA, and testB dirs.' % x)
+    return x
+
+parser = argparse.ArgumentParser(description='Convert training and testing images to tfrecords files.')
+subp = parser.add_subparsers(title='subcommands', description='valid subcommands', dest='command')
+
+prepped = subp.add_parser('prepped', aliases=['p'], help='For files already split into trainA/trainB/testA/testB')
+prepped.add_argument('--files', type=exists, help='Location of training files', required=True)
+prepped.add_argument('-o', '--output-prefix', help='Prefix file/path for output tfrecords files', required=True,
+                    dest='output_prefix')
+
+raw = subp.add_parser('raw')
+raw.add_argument('--d1', '--dir1', '--directory1', dest='dir_1', help='Directory containing "Set A" of images.', required=True)
+raw.add_argument('--d2', '--dir2', '--directory2', dest='dir_2', help='Directory containing "Set B" of images.', required=True)
+raw.add_argument('-s', '--split', dest='split_pct', type=int, default=70, help='Split percent for training set.')
+raw.add_argument('--outdir', '--out-dir', dest='out_dir', help='Will split the data and store in "prepped" format into this directory.', required=True)
+raw.add_argument('-o', '--output-prefix', help='Prefix file/path for output tfrecords files', required=True,
+                    dest='output_prefix')
+
+def reader(path, shuffle=True):
+    files = []
+
+    for img_file in os.scandir(path):
+        if img_file.name.endswith('.jpg') and img_file.is_file():
+            files.append(img_file.path)
+
+    if shuffle:
+        # Shuffle the ordering of all image files in order to guarantee
+        # random ordering of the images with respect to label in the
+        # saved TFRecord files. Make the randomization repeatable.
+        shuffled_index = list(range(len(files)))
+        random.shuffle(files)
+
+        files = [files[i] for i in shuffled_index]
+
+    return files
+
+def raw_writer(dir_1, dir_2, split, out_dir, output_prefix):
+    files_1 = reader(dir_1)
+    n_train_1 = int(len(files_1) * float(split) / 100.)
+    files_2 = reader(dir_2)
+    n_train_2 = int(len(files_2) * float(split) / 100.)
+    train_1, test_1 = files_1[:n_train_1], files_1[n_train_1:]
+    train_2, test_2 = files_2[:n_train_2], files_2[n_train_2:]
+
+    for sub, files in [('trainA', train_1), ('trainB', train_2), ('testA', test_1), ('testB', test_2)]:
+        cur_dir = os.path.join(out_dir, sub)
+        os.makedirs(cur_dir, exist_ok=True)
+        for file in files:
+            copyfile(file, os.path.join(cur_dir, os.path.basename(file)))
+
+    prepped_writer(out_dir, output_prefix)
+
+def prepped_writer(root_path, output_prefix):
+    as_bytes = lambda data: tf.train.Feature(bytes_list=tf.train.BytesList(value=[data]))
+    as_example = lambda fn, data: tf.train.Example(features=tf.train.Features(feature={
+        'image/file_name': as_bytes(tf.compat.as_bytes(os.path.basename(fn))),
+        'image/encoded_image': as_bytes((data))
+    }))
+
+    for sub in ['trainA', 'trainB', 'testA', 'testB']:
+        indir = os.path.join(root_path, sub)
+        outfile = os.path.abspath('{}_{}.tfrecords'.format(output_prefix, sub))
+        files = reader(indir)
+
+        # Ensure output directory exists
+        os.makedirs(os.path.dirname(outfile), exist_ok=True)
+
+        record_writer = tf.python_io.TFRecordWriter(outfile)
+
+        for ix, file in enumerate(files):
+            with tf.gfile.FastGFile(file, 'rb') as f:
+                image_data = f.read()
+
+            example = as_example(file, image_data)
+            record_writer.write(example.SerializeToString())
+
+            if ix % 500 == 0:
+                print('Processed {}/{}.'.format(ix, len(files)))
+        print('Done.')
+        record_writer.close()
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    result = parser.parse_args()
+    if result.command == 'raw':
+        raw_writer(result.dir_1, result.dir_2, result.split_pct, result.out_dir, result.output_prefix)
+    else:
+        prepped_writer(result.files, result.output_prefix)


### PR DESCRIPTION
I found it far easier to used my "cooked" tfrecords format as an input source than cope with image reading during training. Also, found it much easier to just deal with both inputs and sampling in tensor space than in "real"(numpy/scipy)-space. Also, swapped your ImagePool implementation for my ImageCache implementation since it starts using cached images a lot more aggressively.

Dropping your "join-both-images-into-a-single-array" logic as it makes scoring more tedious and is just kind of weird.

I also dropped your "early-out" logic flag in favor of the more tensorflow-thonic coordinator-based quitting, and do the same on exceptions, _and_ save the model checkpoint in a finally block so it should always be saved.

One note: I have _not_ tested the model with the cycleganTest.py script, I'll do that tomorrow morning.