### PR TITLE
Minor help tweaks

### DIFF
--- a/cyclegan.py
+++ b/cyclegan.py
@@ -44,7 +44,7 @@ def parseArguments():
     # Optional arguments
     parser.add_argument('-log', '--logdir', dest='logdir', help='Log directory', default=LOG_DIR)
     parser.add_argument('-i', '--input', '--input_prefix', dest='input_prefix',
-                                            help="Input prefix for tfrecords files.", required=True)
+                                            help="Input prefix for tfrecords files (use to_tfrecords.py to generate).", required=True)
     parser.add_argument("-t", "--time", help="Max time (mins) to run training", type=int, default=60 * 10)
     parser.add_argument("-l", "--lrate", help="Learning rate", type=float, default=LEARNING_RATE)
     parser.add_argument("-lf", "--log-freq", dest="log_frequency", help= "How often writer should add summaries", default=LOG_FREQUENCY, type=int)

--- a/cyclegan.py
+++ b/cyclegan.py
@@ -251,6 +251,9 @@ def generator(image, norm='batch', rnorm='instance', reuse=False, name="generato
             tf.variable_scope(tf.get_variable_scope(), reuse=False)
             assert tf.get_variable_scope().reuse == False
 
+        # CycleGAN code has two differences from typical Residual blocks
+        # 1) They use instance normalization instead of batch normalization
+        # 2) They are missing the final ReLU nonlinearity after joining with pass-through
         def residual_block(x, dim, ks=3, s=1, norm='instance', name='res', reuse=reuse):
             p = int((ks - 1) / 2)
             y = tf.pad(x, [[0, 0], [p, p], [p, p], [0, 0]], "REFLECT")

--- a/to_tfrecords.py
+++ b/to_tfrecords.py
@@ -20,13 +20,13 @@ def exists(x):
 parser = argparse.ArgumentParser(description='Convert training and testing images to tfrecords files.')
 subp = parser.add_subparsers(title='subcommands', description='valid subcommands', dest='command')
 
-prepped = subp.add_parser('prepped', aliases=['p'], help='For files already split into trainA/trainB/testA/testB')
+prepped = subp.add_parser('prepped', aliases=['p'], help='For files already split into trainA/trainB/testA/testB.')
 prepped.add_argument('--files', type=exists, help='Location of training files', required=True)
 prepped.add_argument('-o', '--output-prefix', help='Prefix file/path for output tfrecords files', required=True,
                     dest='output_prefix')
 prepped.add_argument('-n', '--num-test', dest='num_test', type=int, help='Number of examples to include in test sets.', default=-1)
 
-raw = subp.add_parser('raw')
+raw = subp.add_parser('raw', help='Turns two directories of images into the trainA/trainB/testA/testB directories, as well as the tfrecords files.')
 raw.add_argument('--d1', '--dir1', '--directory1', dest='dir_1', help='Directory containing "Set A" of images.', required=True)
 raw.add_argument('--d2', '--dir2', '--directory2', dest='dir_2', help='Directory containing "Set B" of images.', required=True)
 raw.add_argument('-s', '--split', dest='split_pct', type=int, default=70, help='Split percent for training set.')
@@ -107,5 +107,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.command == 'raw':
         raw_writer(args.dir_1, args.dir_2, args.split_pct, args.out_dir, args.output_prefix, args.num_test)
-    else:
+    elif args.command == 'prepped':
         prepped_writer(args.files, args.output_prefix, args.num_test)
+    else:
+        parser.print_help()


### PR DESCRIPTION
Make `to_tfrecords.py` dump out help text when run without arguments, add help description for `raw` command. Add reference to `to_tfrecords.py` to the help text for `-i` in `cyclegan.py`.